### PR TITLE
sanitize GET value for instagram admin

### DIFF
--- a/social_wall_instagram/social_wall_instagram.admin.inc
+++ b/social_wall_instagram/social_wall_instagram.admin.inc
@@ -67,7 +67,7 @@ function social_wall_instagram_connect() {
     drupal_goto($provider->getAuthorizationUrl());
   }
 
-  $provider->setCode($_GET['code']);
+  $provider->setCode(check_plain($_GET['code']));
 
   $token = $provider->getToken();
 


### PR DESCRIPTION
A fix to properly sanitize $_GET values.